### PR TITLE
update $rootPath so it doesn't assume the library lives at webroot

### DIFF
--- a/_tmpl/functions.php
+++ b/_tmpl/functions.php
@@ -1,7 +1,7 @@
 <?php
 // Modified from Paul Robert Lloyd's Barebones
 // Config options
-$rootPath = $_SERVER['DOCUMENT_ROOT'];
+$rootPath = __DIR__;
 $styleguidePath = '/';
 $patternsPath = $rootPath.'/patterns/';
 $cssPath = $rootPath.'/css/';


### PR DESCRIPTION
Our production environment (and many shared-hosting environments) don't allow the flexibility of having files outside of the web root.

Changing `$rootPath` to report the current directory, instead of the web root, adds the flexibility to have the library at a level other than the web root.
